### PR TITLE
Task 6 - less restrictive description

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please perform the following tasks in Python using the *delays_2018.csv*, *delay
 3. Display a list of all Tennessee airports that appear in the dataset.
 4. Import the coordinates dataset and merge it with the existing dataset.  Plot the coordinates of all airports on a map (hint: use Matplotlib and Basemap).
 5. Display the number of diverted flights for each carrier-airport pair.
-6. Display how many arrivals into JFK in 2019 encountered both weather and carrier delays?
+6. Display how many arrivals into JFK in 2019 encountered either weather or carrier delays (or both)?
 7. Display the airline with the most flight cancellations as a percentage of total arriving flights.
 8. Determine the overall average number of delays per airport.
 9. Display the three carriers with the lowest number of delayed flights.


### PR DESCRIPTION
Hi,
first of all, thanks for this repo, the tasks are really nicely thought out, fairly challenging and I love that you included test data already. I am having fun completing this as learning by doing is my favourite as well.
Here's my proposed change - in task 6, I would prefer it to clearly state that one can sum both `carrier_ct` OR `weather_ct` as it confused me - I thought that it is required to count only instances of flights where both kinds of delays were present (which is impossible to accomplish ofc., as we don't have data about every single flight available).
After looking at your solution, I saw you summed both kinds of delays together, which means that at least one of them should be present.
So I allowed myself to propose a little tweak so that it can get the message accross a bit better :-)